### PR TITLE
Bugfix/avoid ts type issue

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export declare interface SectionControllerProps
   > {
   children: React.ReactNode;
   threshold?: number;
-  containerRef?: React.LegacyRef<HTMLDivElement> | undefined;
+  containerRef?: React.RefObject<HTMLDivElement> | null;
 }
 
 export declare interface SectionProps {


### PR DESCRIPTION
change to avoid Type 'LegacyRef<HTMLDivElement>' is not assignable to type 'RefObject<HTMLDivElement>'.
  Type 'string' is not assignable to type 'RefObject<HTMLDivElement>' issue 